### PR TITLE
Groups

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { QrcodeModule } from './qrcode/qrcode.module';
 import { RedirectModule } from './redirect/redirect.module';
 import { UsersModule } from './users/users.module';
 import configuration, { ConfigKeys } from './utils/configuration';
+import { GroupsModule } from './groups/groups.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import configuration, { ConfigKeys } from './utils/configuration';
     RedirectModule,
     QrcodeModule,
     PollModule,
+    GroupsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/packages/backend/src/groups/groups.controller.ts
+++ b/packages/backend/src/groups/groups.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { UserDocument } from 'src/schemas/users.schema';
 import { JwtAuthGuard } from 'src/strategies/jwt.strategy';
 import { AddMemberDto, CreateGroupDto } from 'src/types/group.dto';
@@ -28,9 +28,9 @@ export class GroupsController {
   }
 
   @Get()
-  findAll(@Req() req) {
+  findAll(@Req() req, @Query('with-admin') withAdmin: string) {
     const user = req.user as UserDocument;
-    return this.groupsService.findAll(user);
+    return this.groupsService.findAll(user, withAdmin === 'true');
   }
 
   @Get(':id')

--- a/packages/backend/src/groups/groups.controller.ts
+++ b/packages/backend/src/groups/groups.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Req } from '@nestjs/common';
+import { GroupsService } from './groups.service';
+import { JwtAuthGuard } from 'src/strategies/jwt.strategy';
+import { AddMembersDto, CreateGroupDto } from 'src/types/group.dto';
+import { UserDocument } from 'src/schemas/users.schema';
+
+@UseGuards(JwtAuthGuard)
+@Controller('groups')
+export class GroupsController {
+  constructor(private readonly groupsService: GroupsService) {}
+
+  @Post()
+  create(@Req() req, @Body() createGroupDto: CreateGroupDto) {
+    const user = req.user as UserDocument;
+    return this.groupsService.create(createGroupDto, user._id);
+  }
+
+  @Post(':id/members/')
+  addMembers(@Req() req, @Param('id') id: string, @Body() dto: AddMembersDto) {
+    const user = req.user as UserDocument;
+    return this.groupsService.addMembers(dto, id, user._id);
+  }
+
+  @Delete(':id/members/')
+  removeMembers(@Req() req, @Param('id') id: string, @Body() dto: AddMembersDto) {
+    const user = req.user as UserDocument;
+    return this.groupsService.removeMembers(dto, id, user._id);
+  }
+
+  @Get()
+  findAll(@Req() req) {
+    const user = req.user as UserDocument;
+    return this.groupsService.findAll(user);
+  }
+
+  @Get(':id')
+  findOne(@Req() req, @Param('id') id: string) {
+    const user = req.user as UserDocument;
+    return this.groupsService.findOne(id, user);
+  }
+
+  @Patch(':id')
+  update(@Req() req, @Param('id') id: string, @Body() updateGroupDto: CreateGroupDto) {
+    const user = req.user as UserDocument;
+    return this.groupsService.update(id, updateGroupDto, user._id);
+  }
+
+  @Delete(':id')
+  remove(@Req() req, @Param('id') id: string) {
+    const user = req.user as UserDocument;
+    return this.groupsService.remove(id, user._id);
+  }
+}

--- a/packages/backend/src/groups/groups.controller.ts
+++ b/packages/backend/src/groups/groups.controller.ts
@@ -5,7 +5,7 @@ import { AddMembersDto, CreateGroupDto } from 'src/types/group.dto';
 import { UserDocument } from 'src/schemas/users.schema';
 
 @UseGuards(JwtAuthGuard)
-@Controller('groups')
+@Controller('admin/groups')
 export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}
 

--- a/packages/backend/src/groups/groups.controller.ts
+++ b/packages/backend/src/groups/groups.controller.ts
@@ -1,8 +1,8 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Req } from '@nestjs/common';
-import { GroupsService } from './groups.service';
-import { JwtAuthGuard } from 'src/strategies/jwt.strategy';
-import { AddMembersDto, CreateGroupDto } from 'src/types/group.dto';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { UserDocument } from 'src/schemas/users.schema';
+import { JwtAuthGuard } from 'src/strategies/jwt.strategy';
+import { AddMemberDto, CreateGroupDto } from 'src/types/group.dto';
+import { GroupsService } from './groups.service';
 
 @UseGuards(JwtAuthGuard)
 @Controller('admin/groups')
@@ -16,15 +16,15 @@ export class GroupsController {
   }
 
   @Post(':id/members/')
-  addMembers(@Req() req, @Param('id') id: string, @Body() dto: AddMembersDto) {
+  addMember(@Req() req, @Param('id') id: string, @Body() dto: AddMemberDto) {
     const user = req.user as UserDocument;
-    return this.groupsService.addMembers(dto, id, user._id);
+    return this.groupsService.addMember(dto, id, user._id);
   }
 
-  @Delete(':id/members/')
-  removeMembers(@Req() req, @Param('id') id: string, @Body() dto: AddMembersDto) {
+  @Delete(':id/members/:memberId')
+  removeMembers(@Req() req, @Param('id') id: string, @Param('memberId') memberId: string) {
     const user = req.user as UserDocument;
-    return this.groupsService.removeMembers(dto, id, user._id);
+    return this.groupsService.removeMember(memberId, id, user._id);
   }
 
   @Get()

--- a/packages/backend/src/groups/groups.module.ts
+++ b/packages/backend/src/groups/groups.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { GroupsService } from './groups.service';
+import { GroupsController } from './groups.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Group, GroupSchema } from 'src/schemas/group.schema';
+import { Poll, PollSchema } from 'src/schemas/poll.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Group.name, schema: GroupSchema },
+      { name: Poll.name, schema: PollSchema },
+    ]),
+  ],
+  controllers: [GroupsController],
+  providers: [GroupsService],
+})
+export class GroupsModule {}

--- a/packages/backend/src/groups/groups.module.ts
+++ b/packages/backend/src/groups/groups.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { User, UserSchema } from '../schemas/users.schema';
 import { GroupsService } from './groups.service';
 import { GroupsController } from './groups.controller';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -10,6 +11,7 @@ import { Poll, PollSchema } from 'src/schemas/poll.schema';
     MongooseModule.forFeature([
       { name: Group.name, schema: GroupSchema },
       { name: Poll.name, schema: PollSchema },
+      { name: User.name, schema: UserSchema },
     ]),
   ],
   controllers: [GroupsController],

--- a/packages/backend/src/groups/groups.service.ts
+++ b/packages/backend/src/groups/groups.service.ts
@@ -1,0 +1,81 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Group } from 'src/schemas/group.schema';
+import { Poll } from 'src/schemas/poll.schema';
+import { UserDocument } from 'src/schemas/users.schema';
+import { AddMembersDto, CreateGroupDto } from 'src/types/group.dto';
+
+@Injectable()
+export class GroupsService {
+  constructor(
+    @InjectModel(Group.name) private readonly groupModel: Model<Group>,
+    @InjectModel(Poll.name) private readonly pollModel: Model<Poll>
+  ) {}
+
+  create(dto: CreateGroupDto, userId: Types.ObjectId) {
+    return this.groupModel.create({ ...dto, admin: userId });
+  }
+
+  async addMembers(dto: AddMembersDto, groupId: string, userId: Types.ObjectId) {
+    const group = await this.groupModel.findOne({ admin: userId, _id: groupId });
+    if (!group) {
+      throw new ForbiddenException('Nincs jogod tagok hozzáadásához!');
+    }
+    const uniqueMembers = new Set([...group.memberIds, ...dto.members]);
+    return await this.groupModel.updateOne(
+      { _id: groupId },
+      { $set: { memberIds: Array.from(uniqueMembers.values()) } }
+    );
+  }
+
+  async removeMembers(dto: AddMembersDto, groupId: string, userId: Types.ObjectId) {
+    const group = await this.groupModel.findOne({ admin: userId });
+    if (!group) {
+      throw new ForbiddenException('Nincs jogod tagok törléséhez!');
+    }
+    const uniqueMembers = group.memberIds.filter((m) => !dto.members.includes(m));
+    return await this.groupModel.updateOne({ _id: groupId }, { $set: { memberIds: uniqueMembers } });
+  }
+
+  async findAll(user: UserDocument) {
+    const groups = await this.groupModel.find({
+      $or: [{ admin: user._id }, { memberIds: user.authId }],
+    });
+    return groups.map((group) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { admin, memberIds, ...g } = group.toJSON();
+      return { ...g, isAdmin: admin.toString() === user._id.toString() };
+    });
+  }
+
+  async findOne(id: string, user: UserDocument) {
+    const group = await this.groupModel.findOne({
+      _id: id,
+      $or: [{ admin: user._id }, { members: user.authId }],
+    });
+    if (!group) {
+      throw new NotFoundException('A csoport nem található!');
+    }
+    const polls = await this.pollModel.find({ group: id });
+    return { ...group.toJSON(), polls };
+  }
+
+  async update(id: string, dto: CreateGroupDto, userId: Types.ObjectId) {
+    const group = await this.groupModel.findOne({ admin: userId });
+    if (!group) {
+      throw new ForbiddenException('Nincs jogod a csoport szerkesztéséhez!');
+    }
+
+    return this.groupModel.updateOne({ _id: id }, { $set: dto });
+  }
+
+  async remove(id: string, userId: Types.ObjectId) {
+    const group = await this.groupModel.findOne({ admin: userId });
+    if (!group) {
+      throw new ForbiddenException('Nincs jogod a csoport törléséhez!');
+    }
+
+    return this.groupModel.deleteOne({ _id: id });
+  }
+}

--- a/packages/backend/src/groups/groups.service.ts
+++ b/packages/backend/src/groups/groups.service.ts
@@ -15,7 +15,7 @@ export class GroupsService {
   ) {}
 
   create(dto: CreateGroupDto, userId: Types.ObjectId) {
-    return this.groupModel.create({ ...dto, admin: userId, memberIds: [userId] });
+    return this.groupModel.create({ ...dto, admin: userId });
   }
 
   async addMember(dto: AddMemberDto, groupId: string, userId: Types.ObjectId) {

--- a/packages/backend/src/groups/groups.service.ts
+++ b/packages/backend/src/groups/groups.service.ts
@@ -71,7 +71,7 @@ export class GroupsService {
   }
 
   async remove(id: string, userId: Types.ObjectId) {
-    const group = await this.groupModel.findOne({ admin: userId });
+    const group = await this.groupModel.findOne({ _id: id, admin: userId });
     if (!group) {
       throw new ForbiddenException('Nincs jogod a csoport törléséhez!');
     }

--- a/packages/backend/src/poll/poll.module.ts
+++ b/packages/backend/src/poll/poll.module.ts
@@ -8,10 +8,14 @@ import { SubmissionService } from '../submission/submission.service';
 import { PollController } from './poll.controller';
 import { PublicPollController } from './poll.public.controller';
 import { PollService } from './poll.service';
+import { Group, GroupSchema } from 'src/schemas/group.schema';
+import { User, UserSchema } from 'src/schemas/users.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Poll.name, schema: PollSchema }]),
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    MongooseModule.forFeature([{ name: Group.name, schema: GroupSchema }]),
     MongooseModule.forFeature([{ name: Submission.name, schema: SubmissionSchema }]),
   ],
   providers: [PollService, SubmissionService],

--- a/packages/backend/src/poll/poll.public.controller.ts
+++ b/packages/backend/src/poll/poll.public.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+import { OptionalAuthGuard } from '../auth/auth.guard';
 import { getObjectId } from '../utils/getObjectId';
 import { PollService } from './poll.service';
 
@@ -6,8 +7,9 @@ import { PollService } from './poll.service';
 export class PublicPollController {
   constructor(private readonly pollService: PollService) {}
 
+  @UseGuards(OptionalAuthGuard)
   @Get(':id')
-  async getPoll(@Param('id') id: string) {
-    return await this.pollService.getPublicPollById(getObjectId(id));
+  async getPoll(@Param('id') id: string, @Req() req) {
+    return await this.pollService.getPublicPollById(getObjectId(id), req.user);
   }
 }

--- a/packages/backend/src/poll/poll.service.ts
+++ b/packages/backend/src/poll/poll.service.ts
@@ -52,7 +52,7 @@ export class PollService {
       notVoted = members.filter((user) => !submissionNames.includes(user.authId)).map((user) => user.displayName);
     }
 
-    if (pollWithSubmissions.enabled) {
+    if (pollWithSubmissions.enabled || submissions.length === 0) {
       return { ...poll, notVoted };
     } else {
       const results: ConfidentialPollResult[] = poll.answerOptions.map((k) => ({

--- a/packages/backend/src/schemas/group.schema.ts
+++ b/packages/backend/src/schemas/group.schema.ts
@@ -1,0 +1,25 @@
+import { Prop, SchemaFactory, Schema } from '@nestjs/mongoose';
+import { IsString, IsNotEmpty, IsArray } from 'class-validator';
+import { HydratedDocument, Types } from 'mongoose';
+import { UserSchema } from './users.schema';
+
+export type GroupDocument = HydratedDocument<Group>;
+
+@Schema()
+export class Group {
+  @Prop({ required: true })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @Prop({ type: Types.ObjectId, refPath: UserSchema })
+  admin: Types.ObjectId;
+
+  @Prop()
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  memberIds: string[];
+}
+
+export const GroupSchema = SchemaFactory.createForClass(Group);

--- a/packages/backend/src/schemas/poll.schema.ts
+++ b/packages/backend/src/schemas/poll.schema.ts
@@ -2,6 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { IsBoolean, IsEnum, IsString } from 'class-validator';
 import { HydratedDocument, Types } from 'mongoose';
 import { User } from './users.schema';
+import { Group } from './group.schema';
 
 export type PollDocument = HydratedDocument<Poll>;
 
@@ -39,6 +40,9 @@ export class Poll {
 
   @Prop({ type: Types.ObjectId, ref: User.name })
   user: User;
+
+  @Prop({ type: Types.ObjectId, ref: Group.name, required: false })
+  group?: Group;
 }
 
 export const PollSchema = SchemaFactory.createForClass(Poll);

--- a/packages/backend/src/submission/submission.controller.ts
+++ b/packages/backend/src/submission/submission.controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { OptionalAuthGuard } from 'src/auth/auth.guard';
 import { CreateSubmissionDto } from '../types/submission.dto';
 import { SubmissionService } from './submission.service';
-import { OptionalAuthGuard } from 'src/auth/auth.guard';
 
 @Controller('submission')
 export class SubmissionController {

--- a/packages/backend/src/submission/submission.service.ts
+++ b/packages/backend/src/submission/submission.service.ts
@@ -7,10 +7,10 @@ import {
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
+import { UserDocument } from 'src/schemas/users.schema';
 import { Poll } from '../schemas/poll.schema';
 import { Submission } from '../schemas/submission.schema';
 import { CreateSubmissionDto } from '../types/submission.dto';
-import { User } from 'src/schemas/users.schema';
 
 @Injectable()
 export class SubmissionService {
@@ -19,14 +19,14 @@ export class SubmissionService {
     @InjectModel(Poll.name) private readonly pollModel: Model<Poll>
   ) {}
 
-  async createSubmission(pollId: string, dto: CreateSubmissionDto, user: User | undefined) {
+  async createSubmission(pollId: string, dto: CreateSubmissionDto, user: UserDocument | undefined) {
     const poll = await this.pollModel.findById(pollId).populate('group');
     if (!poll) throw new NotFoundException('Űrlap nem található');
     if (!poll.enabled) return new ForbiddenException('A kitöltés nem engedélyezett!');
     if (!user && (poll.group || poll.confidential)) {
       throw new UnauthorizedException('A szavazáshoz be kell jelentkezned!');
     }
-    if (poll.group && !poll.group.memberIds.includes(user.authId)) {
+    if (poll.group && !poll.group.memberIds.includes(user._id.toString())) {
       throw new ForbiddenException('Te nem szavazhatsz ezen a szavazáson!');
     }
     if (poll.confidential) {

--- a/packages/backend/src/submission/submission.service.ts
+++ b/packages/backend/src/submission/submission.service.ts
@@ -1,4 +1,10 @@
-import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Poll } from '../schemas/poll.schema';
@@ -14,9 +20,15 @@ export class SubmissionService {
   ) {}
 
   async createSubmission(pollId: string, dto: CreateSubmissionDto, user: User | undefined) {
-    const poll = await this.pollModel.findById(pollId);
+    const poll = await this.pollModel.findById(pollId).populate('group');
     if (!poll) throw new NotFoundException('Űrlap nem található');
     if (!poll.enabled) return new ForbiddenException('A kitöltés nem engedélyezett!');
+    if (!user && (poll.group || poll.confidential)) {
+      throw new UnauthorizedException('A szavazáshoz be kell jelentkezned!');
+    }
+    if (poll.group && !poll.group.memberIds.includes(user.authId)) {
+      throw new ForbiddenException('Te nem szavazhatsz ezen a szavazáson!');
+    }
     if (poll.confidential) {
       const submissions = await this.submissionModel.find({ name: user.authId, poll: poll._id });
       if (submissions.length > 0) throw new ConflictException('Már szavaztál ezen a szavazáson!');

--- a/packages/backend/src/submission/submission.service.ts
+++ b/packages/backend/src/submission/submission.service.ts
@@ -29,7 +29,7 @@ export class SubmissionService {
     if (poll.group && !poll.group.memberIds.includes(user._id.toString())) {
       throw new ForbiddenException('Te nem szavazhatsz ezen a szavazáson!');
     }
-    if (poll.confidential) {
+    if (poll.confidential || poll.group) {
       const submissions = await this.submissionModel.find({ name: user.authId, poll: poll._id });
       if (submissions.length > 0) throw new ConflictException('Már szavaztál ezen a szavazáson!');
     }

--- a/packages/backend/src/types/group.dto.ts
+++ b/packages/backend/src/types/group.dto.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateGroupDto {
   @IsString()
@@ -10,6 +10,7 @@ export class CreateGroupDto {
 
 export class AddMembersDto {
   @IsString({ each: true })
+  @IsArray()
   @Expose()
   @IsNotEmpty({ each: true })
   members: string[];

--- a/packages/backend/src/types/group.dto.ts
+++ b/packages/backend/src/types/group.dto.ts
@@ -1,5 +1,8 @@
 import { Expose } from 'class-transformer';
-import { IsArray, IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
+import { Group } from '../schemas/group.schema';
+import { PollDocument } from '../schemas/poll.schema';
+import { UserDocument } from '../schemas/users.schema';
 
 export class CreateGroupDto {
   @IsString()
@@ -8,10 +11,30 @@ export class CreateGroupDto {
   name: string;
 }
 
-export class AddMembersDto {
-  @IsString({ each: true })
-  @IsArray()
+export class AddMemberDto {
+  @IsString()
   @Expose()
-  @IsNotEmpty({ each: true })
-  members: string[];
+  @IsNotEmpty()
+  memberMail: string;
+}
+
+export class RemoveMemberDto {
+  @IsString()
+  @Expose()
+  @IsNotEmpty()
+  memberId: string;
+}
+
+export class GroupDto implements Pick<Group, 'name'> {
+  @Expose()
+  name: string;
+
+  @Expose()
+  isAdmin: boolean;
+
+  @Expose()
+  polls: PollDocument[];
+
+  @Expose()
+  members: UserDocument[];
 }

--- a/packages/backend/src/types/group.dto.ts
+++ b/packages/backend/src/types/group.dto.ts
@@ -1,0 +1,16 @@
+import { Expose } from 'class-transformer';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateGroupDto {
+  @IsString()
+  @IsNotEmpty()
+  @Expose()
+  name: string;
+}
+
+export class AddMembersDto {
+  @IsString({ each: true })
+  @Expose()
+  @IsNotEmpty({ each: true })
+  members: string[];
+}

--- a/packages/backend/src/types/poll.dto.ts
+++ b/packages/backend/src/types/poll.dto.ts
@@ -68,6 +68,7 @@ type Poll = {
   enabled: boolean;
   confidential: boolean;
   question: string;
+  group: string;
   type: PollType;
   answerOptions: string[];
 };

--- a/packages/backend/src/types/poll.dto.ts
+++ b/packages/backend/src/types/poll.dto.ts
@@ -29,6 +29,12 @@ export class CreatePollDto {
   @Expose()
   type: PollType;
 
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @Expose()
+  group?: string;
+
   @IsString({ each: true })
   @Expose()
   answerOptions: string[];

--- a/packages/frontend/src/components/group/AddMember.tsx
+++ b/packages/frontend/src/components/group/AddMember.tsx
@@ -1,0 +1,40 @@
+import { Button, HStack, Input, Text } from '@chakra-ui/react';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+
+import { useAddMemberToGroup } from '../../network/groups/useAddMemberToGroup.network';
+import { AddMemberToGroupDto } from '../../types/dto.types';
+import { l } from '../../utils/language';
+import { addMemberValidation } from '../../utils/validation';
+
+interface AddMemberProps {
+  groupId: string;
+  onAddMember: () => void;
+}
+
+export function AddMember({ groupId, onAddMember }: AddMemberProps) {
+  const addMember = useAddMemberToGroup(groupId);
+
+  const { register, handleSubmit } = useForm<AddMemberToGroupDto>({
+    resolver: yupResolver(addMemberValidation),
+  });
+
+  const onSubmit = handleSubmit((data) => {
+    addMember.mutateAsync(data).then(() => {
+      onAddMember();
+    });
+  });
+
+  return (
+    <form onSubmit={onSubmit}>
+      <Text mt={10}>{l('page.groups.addMember')}</Text>
+      <HStack mt={2}>
+        <Input w='md' {...register('memberMail')} />
+        <Button isLoading={addMember.isLoading} type='submit'>
+          {l('button.add')}
+        </Button>
+      </HStack>
+      {addMember.isError && <Text color='red.500'>{l('error.addMember')}</Text>}
+    </form>
+  );
+}

--- a/packages/frontend/src/components/group/GroupListItem.tsx
+++ b/packages/frontend/src/components/group/GroupListItem.tsx
@@ -1,0 +1,32 @@
+import { HStack, Text, useColorModeValue } from '@chakra-ui/react';
+import { TbChevronRight } from 'react-icons/tb';
+import { useNavigate } from 'react-router-dom';
+
+import { UIPaths } from '../../config/paths.config';
+import { GroupDocument } from '../../types/types';
+import { joinPath } from '../../utils/path';
+
+interface GroupListItemProps {
+  group: GroupDocument;
+}
+export function GroupListItem({ group }: GroupListItemProps) {
+  const color = useColorModeValue('gray.100', 'gray.600');
+  const navigate = useNavigate();
+  const onClick = () => navigate(joinPath(UIPaths.GROUP, group._id));
+  return (
+    <HStack
+      p={3}
+      cursor='pointer'
+      justify='space-between'
+      borderRadius='md'
+      borderColor={color}
+      borderWidth={1}
+      w='100%'
+      _hover={{ background: color }}
+      onClick={onClick}
+    >
+      <Text>{group.name}</Text>
+      <TbChevronRight />
+    </HStack>
+  );
+}

--- a/packages/frontend/src/components/group/MemberListItem.tsx
+++ b/packages/frontend/src/components/group/MemberListItem.tsx
@@ -1,0 +1,38 @@
+import { Button, HStack, Text, useColorModeValue } from '@chakra-ui/react';
+import { TbCircleMinus } from 'react-icons/tb';
+
+import { useRemoveMemberFromGroup } from '../../network/groups/useRemoveMemberFromGroup.network';
+import { UserDocument } from '../../types/types';
+
+interface MemberListItemProps {
+  removeEnabled?: boolean;
+  groupId: string;
+  member: UserDocument;
+  onDelete?: () => void;
+}
+
+export function MemberListItem({ member, onDelete, groupId, removeEnabled }: MemberListItemProps) {
+  const removeMemberFromGroup = useRemoveMemberFromGroup(groupId);
+  const bgColor = useColorModeValue('gray.100', 'gray.600');
+  const onRemove = async () => {
+    removeMemberFromGroup.mutateAsync({ memberId: member._id }).then(() => {
+      onDelete && onDelete();
+    });
+  };
+  return (
+    <HStack justifyContent='space-between' p={3} backgroundColor={bgColor} borderRadius='lg' w='100%'>
+      <Text isTruncated>{member.displayName}</Text>
+      {removeEnabled && onDelete && (
+        <Button
+          isLoading={removeMemberFromGroup.isLoading}
+          onClick={onRemove}
+          colorScheme='red'
+          variant='ghost'
+          size='sm'
+        >
+          <TbCircleMinus />
+        </Button>
+      )}
+    </HStack>
+  );
+}

--- a/packages/frontend/src/components/poll/AnswerOptionsField.tsx
+++ b/packages/frontend/src/components/poll/AnswerOptionsField.tsx
@@ -26,6 +26,10 @@ function StringList({ value = [], onChange }: StringListProps) {
     onChange([...value, '']);
   };
 
+  const handleAddTriple = () => {
+    onChange([...value, 'Igen', 'Nem', 'Tartózkodom']);
+  };
+
   const handleDeleteItem = (index: number) => {
     const updatedValue = [...value];
     updatedValue.splice(index, 1);
@@ -92,9 +96,14 @@ function StringList({ value = [], onChange }: StringListProps) {
           </IconButton>
         </HStack>
       ))}
-      <Button onClick={handleAddItem} variant='ghost' leftIcon={<TbPlus />}>
-        {l('button.add')}
-      </Button>
+      <HStack>
+        <Button onClick={handleAddItem} variant='ghost' leftIcon={<TbPlus />}>
+          {l('button.addOption')}
+        </Button>
+        <Button onClick={handleAddTriple} variant='ghost' leftIcon={<TbPlus />}>
+          {l('button.triple')}
+        </Button>
+      </HStack>
     </VStack>
   );
 }

--- a/packages/frontend/src/components/poll/ConfidentialVoteResult.tsx
+++ b/packages/frontend/src/components/poll/ConfidentialVoteResult.tsx
@@ -1,5 +1,4 @@
 import { Box, Text, VStack } from '@chakra-ui/react';
-import { useMemo } from 'react';
 import { TbAward } from 'react-icons/tb';
 
 import { ConfidentialPollResult, SubmissionAnswerValue } from '../../types/types';
@@ -11,15 +10,12 @@ type Props = {
 };
 
 export function ConfidentialVoteResult({ results }: Props) {
-  const sorted = useMemo(() => {
-    return results.sort((r1, r2) => -r1[SubmissionAnswerValue.YES] - r2[SubmissionAnswerValue.YES]);
-  }, [results]);
   return (
     <Box>
       <IconLabel text={l('page.pollDetails.results')} icon={<TbAward />} />
       <VStack gap={1} alignItems='flex-start'>
-        {sorted.map((result, idx) => (
-          <Text key={result.key} fontWeight={idx === 0 ? 'bold' : 'normal'}>
+        {results.map((result) => (
+          <Text key={result.key}>
             <span style={{ textTransform: 'uppercase' }}>{result.key}</span>: {result[SubmissionAnswerValue.YES]}
           </Text>
         ))}

--- a/packages/frontend/src/components/poll/PublicPollListItem.tsx
+++ b/packages/frontend/src/components/poll/PublicPollListItem.tsx
@@ -1,0 +1,48 @@
+import { Button, HStack, Text, useColorModeValue } from '@chakra-ui/react';
+import { TbChevronRight, TbCircle, TbCircleCheckFilled } from 'react-icons/tb';
+import { useNavigate } from 'react-router-dom';
+
+import { PollWithSubmissionsDocument } from '../../types/types';
+import { joinPath } from '../../utils/path';
+
+interface PublicPollListItemProps {
+  poll: PollWithSubmissionsDocument;
+}
+export function PublicPollListItem({ poll }: PublicPollListItemProps) {
+  const color = useColorModeValue('gray.100', 'gray.600');
+  const navigate = useNavigate();
+  const isDisabled = !poll.enabled;
+  const onClick = () => {
+    if (isDisabled) return;
+    navigate(joinPath('/p', poll._id));
+  };
+  return (
+    <Button
+      opacity={isDisabled ? 0.5 : 1}
+      disabled={isDisabled}
+      h='fit'
+      variant='unstyled'
+      onClick={onClick}
+      borderRadius='md'
+      borderColor={color}
+      borderWidth={1}
+      p={3}
+      _hover={{ background: isDisabled ? undefined : color }}
+      w='100%'
+    >
+      <HStack justify='space-between'>
+        <Text>{poll.name}</Text>
+        <HStack>
+          {poll.submissions.length > 0 ? (
+            <Text color='green.500'>
+              <TbCircleCheckFilled />
+            </Text>
+          ) : (
+            <TbCircle />
+          )}
+          <TbChevronRight />
+        </HStack>
+      </HStack>
+    </Button>
+  );
+}

--- a/packages/frontend/src/config/api.config.ts
+++ b/packages/frontend/src/config/api.config.ts
@@ -7,4 +7,22 @@ export const initAxios = () => {
   axios.defaults.baseURL = API_BASE_URL;
 };
 
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+axios.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export const queryClient = new QueryClient();

--- a/packages/frontend/src/config/menu.config.ts
+++ b/packages/frontend/src/config/menu.config.ts
@@ -1,5 +1,9 @@
-import { TbCheckupList, TbLink, TbListDetails, TbUser } from 'react-icons/tb';
+import { TbCheckupList, TbLink, TbListDetails, TbUser, TbUsers } from 'react-icons/tb';
 
+import { CreateGroupPage } from '../pages/group/CreateGroup.page';
+import { EditGroupPage } from '../pages/group/EditGroup.page';
+import { GroupDetailsPage } from '../pages/group/GroupDetails.page';
+import { GroupsPage } from '../pages/group/Groups.page';
 import { CreateLinkPage } from '../pages/link/CreateLink.page';
 import { EditLinkPage } from '../pages/link/EditLink.page';
 import { LinkDetailsPage } from '../pages/link/LinkDetails.page';
@@ -54,5 +58,23 @@ export const MenuItems: RouterItem[] = [
     path: UIPaths.USERS,
     page: UsersPage,
     admin: true,
+  },
+  {
+    name: l('title.groups'),
+    icon: TbUsers({}),
+    path: UIPaths.GROUP,
+    page: GroupsPage,
+  },
+  {
+    path: UIPaths.NEW_GROUP,
+    page: CreateGroupPage,
+  },
+  {
+    path: UIPaths.GROUP_DETAILS,
+    page: GroupDetailsPage,
+  },
+  {
+    path: UIPaths.EDIT_GROUP,
+    page: EditGroupPage,
   },
 ];

--- a/packages/frontend/src/config/paths.config.ts
+++ b/packages/frontend/src/config/paths.config.ts
@@ -13,6 +13,10 @@ export enum UIPaths {
   NEW_POLL = '/poll/new',
   EDIT_POLL = '/poll/:id/edit',
   DASHBOARD = '/dashboard',
+  GROUP = '/group',
+  GROUP_DETAILS = '/group/:id',
+  NEW_GROUP = '/group/new',
+  EDIT_GROUP = '/group/:id/edit',
   PROFILE = '/profile',
   NOT_FOUND = '/404',
 }
@@ -27,4 +31,5 @@ export enum ApiPaths {
   LOGIN = '/admin/auth/login',
   LINK = '/admin/link',
   LINK_BY_URL = '/admin/link/url',
+  GROUP = '/admin/groups',
 }

--- a/packages/frontend/src/network/groups/useAddMemberToGroup.network.ts
+++ b/packages/frontend/src/network/groups/useAddMemberToGroup.network.ts
@@ -1,1 +1,13 @@
-export function useAddMemberToGroup() {}
+import axios from 'axios';
+import { useMutation } from 'react-query';
+
+import { ApiPaths } from '../../config/paths.config';
+import { AddMemberToGroupDto } from '../../types/dto.types';
+import { joinPath } from '../../utils/path';
+
+export function useAddMemberToGroup(groupId: string) {
+  return useMutation(async (data: AddMemberToGroupDto) => {
+    const response = await axios.post(joinPath(ApiPaths.GROUP, groupId, 'members'), data);
+    return response.data;
+  });
+}

--- a/packages/frontend/src/network/groups/useAddMemberToGroup.network.ts
+++ b/packages/frontend/src/network/groups/useAddMemberToGroup.network.ts
@@ -1,0 +1,1 @@
+export function useAddMemberToGroup() {}

--- a/packages/frontend/src/network/groups/useCreateGroup.network.ts
+++ b/packages/frontend/src/network/groups/useCreateGroup.network.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+
+import { CreateGroupDto } from '../../types/dto.types';
+import { GroupDocument } from '../../types/types';
+
+export function useCreateGroup(onSuccess?: (data: GroupDocument) => void) {
+  return useMutation(
+    async (data: CreateGroupDto) => {
+      const response = await axios.post<GroupDocument>('/admin/groups', data);
+      return response.data;
+    },
+    {
+      onSuccess,
+    }
+  );
+}

--- a/packages/frontend/src/network/groups/useDeleteGroup.network.ts
+++ b/packages/frontend/src/network/groups/useDeleteGroup.network.ts
@@ -1,0 +1,17 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+
+import { ApiPaths } from '../../config/paths.config';
+import { joinPath } from '../../utils/path';
+
+export function useDeleteGroup(id: string | undefined, onSuccess: () => void) {
+  return useMutation(
+    ['deleteGroup', id],
+    async () => {
+      if (!id) return;
+      const response = await axios.delete(joinPath(ApiPaths.GROUP, id));
+      return response.data;
+    },
+    { onSuccess }
+  );
+}

--- a/packages/frontend/src/network/groups/useGroup.network.ts
+++ b/packages/frontend/src/network/groups/useGroup.network.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { useQuery } from 'react-query';
+
+import { GroupDocument } from '../../types/types';
+
+export function useGroup(id: string) {
+  return useQuery(['group', id], async () => {
+    const response = await axios.get<GroupDocument>(`/admin/groups/${id}`);
+    return response.data;
+  });
+}

--- a/packages/frontend/src/network/groups/useGroup.network.ts
+++ b/packages/frontend/src/network/groups/useGroup.network.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
 import { useQuery } from 'react-query';
 
-import { GroupDocument } from '../../types/types';
+import { GroupDetails } from '../../types/types';
 
 export function useGroup(id: string) {
   return useQuery(['group', id], async () => {
-    const response = await axios.get<GroupDocument>(`/admin/groups/${id}`);
+    const response = await axios.get<GroupDetails>(`/admin/groups/${id}`);
     return response.data;
   });
 }

--- a/packages/frontend/src/network/groups/useGroup.network.ts
+++ b/packages/frontend/src/network/groups/useGroup.network.ts
@@ -4,8 +4,12 @@ import { useQuery } from 'react-query';
 import { GroupDetails } from '../../types/types';
 
 export function useGroup(id: string) {
-  return useQuery(['group', id], async () => {
-    const response = await axios.get<GroupDetails>(`/admin/groups/${id}`);
-    return response.data;
-  });
+  return useQuery(
+    ['group', id],
+    async () => {
+      const response = await axios.get<GroupDetails>(`/admin/groups/${id}`);
+      return response.data;
+    },
+    { refetchInterval: 10000 }
+  );
 }

--- a/packages/frontend/src/network/groups/useGroups.network.ts
+++ b/packages/frontend/src/network/groups/useGroups.network.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { useQuery } from 'react-query';
+
+import { ApiPaths } from '../../config/paths.config';
+import { GroupDocument } from '../../types/types';
+
+export function useGroups() {
+  return useQuery('groups', async () => {
+    const response = await axios.get<GroupDocument[]>(ApiPaths.GROUP);
+    return response.data;
+  });
+}

--- a/packages/frontend/src/network/groups/useGroups.network.ts
+++ b/packages/frontend/src/network/groups/useGroups.network.ts
@@ -4,9 +4,10 @@ import { useQuery } from 'react-query';
 import { ApiPaths } from '../../config/paths.config';
 import { GroupDocument } from '../../types/types';
 
-export function useGroups() {
+export function useGroups(withAdmin = false) {
   return useQuery('groups', async () => {
-    const response = await axios.get<GroupDocument[]>(ApiPaths.GROUP);
+    const path = withAdmin ? `${ApiPaths.GROUP}?with-admin=true` : ApiPaths.GROUP;
+    const response = await axios.get<GroupDocument[]>(path);
     return response.data;
   });
 }

--- a/packages/frontend/src/network/groups/useRemoveMemberFromGroup.network.ts
+++ b/packages/frontend/src/network/groups/useRemoveMemberFromGroup.network.ts
@@ -1,0 +1,1 @@
+export function useRemoveMemberFromGroup() {}

--- a/packages/frontend/src/network/groups/useRemoveMemberFromGroup.network.ts
+++ b/packages/frontend/src/network/groups/useRemoveMemberFromGroup.network.ts
@@ -1,1 +1,13 @@
-export function useRemoveMemberFromGroup() {}
+import axios from 'axios';
+import { useMutation } from 'react-query';
+
+import { ApiPaths } from '../../config/paths.config';
+import { RemoveMemberFromGroupDto } from '../../types/dto.types';
+import { joinPath } from '../../utils/path';
+
+export function useRemoveMemberFromGroup(groupId: string) {
+  return useMutation(async (data: RemoveMemberFromGroupDto) => {
+    const response = await axios.delete(joinPath(ApiPaths.GROUP, groupId, 'members', data.memberId));
+    return response.data;
+  });
+}

--- a/packages/frontend/src/network/groups/useUpdateGroup.network.ts
+++ b/packages/frontend/src/network/groups/useUpdateGroup.network.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import { useMutation } from 'react-query';
+
+import { ApiPaths } from '../../config/paths.config';
+import { PatchGroupDto } from '../../types/dto.types';
+import { GroupDocument } from '../../types/types';
+import { joinPath } from '../../utils/path';
+
+export function useUpdateGroup(id: string | undefined, onSuccess: () => void) {
+  return useMutation(
+    ['updateGroup', id],
+    async (body: PatchGroupDto) => {
+      if (!id) return;
+      const response = await axios.patch<GroupDocument>(joinPath(ApiPaths.GROUP, id), body);
+      return response.data;
+    },
+    { onSuccess }
+  );
+}

--- a/packages/frontend/src/network/poll/usePoll.network.ts
+++ b/packages/frontend/src/network/poll/usePoll.network.ts
@@ -6,9 +6,13 @@ import { PollDocumentWithSubmissions } from '../../types/types';
 import { joinPath } from '../../utils/path';
 
 export function usePoll(id: string | undefined) {
-  return useQuery(['polls', id], async () => {
-    if (!id) return;
-    const response = await axios.get<PollDocumentWithSubmissions>(joinPath(ApiPaths.POLL, id));
-    return response.data;
-  });
+  return useQuery(
+    ['polls', id],
+    async () => {
+      if (!id) return;
+      const response = await axios.get<PollDocumentWithSubmissions>(joinPath(ApiPaths.POLL, id));
+      return response.data;
+    },
+    { refetchInterval: 10000 }
+  );
 }

--- a/packages/frontend/src/pages/group/CreateGroup.page.tsx
+++ b/packages/frontend/src/pages/group/CreateGroup.page.tsx
@@ -1,0 +1,66 @@
+import {
+  Button,
+  ButtonGroup,
+  CardBody,
+  CardFooter,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  VStack,
+} from '@chakra-ui/react';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+import { NavButton } from '../../components/button/NavButton';
+import { UIPaths } from '../../config/paths.config';
+import { Page } from '../../layout/Page';
+import { useCreateGroup } from '../../network/groups/useCreateGroup.network';
+import { CreateGroupDto } from '../../types/dto.types';
+import { l } from '../../utils/language';
+import { joinPath } from '../../utils/path';
+import { groupValidation } from '../../utils/validation';
+
+export function CreateGroupPage() {
+  const navigate = useNavigate();
+  const { isLoading, mutate } = useCreateGroup((responseData) => {
+    navigate(joinPath(UIPaths.GROUP, responseData._id));
+  });
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CreateGroupDto>({ resolver: yupResolver(groupValidation) });
+  const onSubmit = (values: CreateGroupDto) => {
+    mutate({
+      name: values.name,
+    });
+  };
+
+  return (
+    <Page title={l('title.createGroup')}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CardBody>
+          <VStack>
+            <FormControl isInvalid={!!errors.name}>
+              <FormLabel>{l('form.group.label.name')}</FormLabel>
+              <Input {...register('name')} />
+              {!!errors.name && <FormErrorMessage>{errors.name.message}</FormErrorMessage>}
+            </FormControl>
+          </VStack>
+        </CardBody>
+        <CardFooter>
+          <ButtonGroup>
+            <Button isLoading={isLoading} type='submit'>
+              {l('button.save')}
+            </Button>
+            <NavButton variant='ghost' to={UIPaths.GROUP}>
+              {l('button.cancel')}
+            </NavButton>
+          </ButtonGroup>
+        </CardFooter>
+      </form>
+    </Page>
+  );
+}

--- a/packages/frontend/src/pages/group/EditGroup.page.tsx
+++ b/packages/frontend/src/pages/group/EditGroup.page.tsx
@@ -1,0 +1,74 @@
+import {
+  Button,
+  ButtonGroup,
+  CardBody,
+  CardFooter,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  VStack,
+} from '@chakra-ui/react';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { NavButton } from '../../components/button/NavButton';
+import { UIPaths } from '../../config/paths.config';
+import { Page } from '../../layout/Page';
+import { useGroup } from '../../network/groups/useGroup.network';
+import { useUpdateGroup } from '../../network/groups/useUpdateGroup.network';
+import { PatchGroupDto } from '../../types/dto.types';
+import { l } from '../../utils/language';
+import { joinPath } from '../../utils/path';
+import { groupValidation } from '../../utils/validation';
+import { ErrorPage } from '../utility/Error.page';
+import { LoadingPage } from '../utility/Loading.page';
+
+export function EditGroupPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const { isLoading, mutate } = useUpdateGroup(id, () => navigate(joinPath(UIPaths.GROUP, id ?? '')));
+  const { isLoading: isLinkLoading, data, isError } = useGroup(id ?? '');
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<PatchGroupDto>({ resolver: yupResolver(groupValidation) });
+  useEffect(() => {
+    reset(data);
+  }, [data]);
+  if (isLinkLoading) return <LoadingPage />;
+  if (!data || isError) return <ErrorPage />;
+  const onSubmit = (values: PatchGroupDto) => {
+    mutate(values);
+  };
+  return (
+    <Page title={l('title.editGroup')}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <CardBody>
+          <VStack>
+            <FormControl isInvalid={!!errors.name}>
+              <FormLabel>{l('form.group.label.name')}</FormLabel>
+              <Input {...register('name')} />
+              {!!errors.name && <FormErrorMessage>{errors.name.message}</FormErrorMessage>}
+            </FormControl>
+            s
+          </VStack>
+        </CardBody>
+        <CardFooter>
+          <ButtonGroup>
+            <Button isLoading={isLoading} type='submit'>
+              {l('button.save')}
+            </Button>
+            <NavButton variant='ghost' to={-1}>
+              {l('button.cancel')}
+            </NavButton>
+          </ButtonGroup>
+        </CardFooter>
+      </form>
+    </Page>
+  );
+}

--- a/packages/frontend/src/pages/group/GroupDetails.page.tsx
+++ b/packages/frontend/src/pages/group/GroupDetails.page.tsx
@@ -11,10 +11,13 @@ import {
   PopoverFooter,
   PopoverTrigger,
   Text,
+  VStack,
 } from '@chakra-ui/react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { NavButton } from '../../components/button/NavButton';
+import { AddMember } from '../../components/group/AddMember';
+import { MemberListItem } from '../../components/group/MemberListItem';
 import { UIPaths } from '../../config/paths.config';
 import { Page } from '../../layout/Page';
 import { useDeleteGroup } from '../../network/groups/useDeleteGroup.network';
@@ -27,7 +30,7 @@ import { LoadingPage } from '../utility/Loading.page';
 export function GroupDetailsPage() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { isLoading, data, isError } = useGroup(id || '');
+  const { isLoading, data, isError, refetch } = useGroup(id || '');
   const {
     isLoading: isDeleteLoading,
     isError: isDeleteError,
@@ -40,33 +43,48 @@ export function GroupDetailsPage() {
   };
   return (
     <Page title={data.name || l('title.unknown')} isLoading={isLoading}>
-      <CardBody></CardBody>
-      <CardFooter>
-        <ButtonGroup>
-          <NavButton to={joinPath(UIPaths.GROUP, id, 'edit')}>{l('button.edit')}</NavButton>
-          <Popover>
-            <PopoverTrigger>
-              <Button colorScheme='red' variant='ghost'>
-                {l('button.delete')}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent>
-              <PopoverCloseButton />
-              <PopoverArrow />
-              <PopoverBody>
-                <Text>{l('header.confirmDelete')}</Text>
-              </PopoverBody>
-              <PopoverFooter>
-                <ButtonGroup>
-                  <Button isLoading={isDeleteLoading} onClick={onDelete} colorScheme='red' variant='ghost'>
-                    {l('button.delete')}
-                  </Button>
-                </ButtonGroup>
-              </PopoverFooter>
-            </PopoverContent>
-          </Popover>
-        </ButtonGroup>
-      </CardFooter>
+      <CardBody>
+        <VStack spacing={4}>
+          {data.members.map((member) => (
+            <MemberListItem
+              onDelete={refetch}
+              key={member._id}
+              member={member}
+              removeEnabled={data.isAdmin}
+              groupId={id}
+            />
+          ))}
+        </VStack>
+        {data.isAdmin && <AddMember groupId={id} onAddMember={refetch} />}
+      </CardBody>
+      {data.isAdmin && (
+        <CardFooter>
+          <ButtonGroup>
+            <NavButton to={joinPath(UIPaths.GROUP, id, 'edit')}>{l('button.edit')}</NavButton>
+            <Popover>
+              <PopoverTrigger>
+                <Button colorScheme='red' variant='ghost'>
+                  {l('button.delete')}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent>
+                <PopoverCloseButton />
+                <PopoverArrow />
+                <PopoverBody>
+                  <Text>{l('header.confirmDelete')}</Text>
+                </PopoverBody>
+                <PopoverFooter>
+                  <ButtonGroup>
+                    <Button isLoading={isDeleteLoading} onClick={onDelete} colorScheme='red' variant='ghost'>
+                      {l('button.delete')}
+                    </Button>
+                  </ButtonGroup>
+                </PopoverFooter>
+              </PopoverContent>
+            </Popover>
+          </ButtonGroup>
+        </CardFooter>
+      )}
     </Page>
   );
 }

--- a/packages/frontend/src/pages/group/GroupDetails.page.tsx
+++ b/packages/frontend/src/pages/group/GroupDetails.page.tsx
@@ -55,6 +55,11 @@ export function GroupDetailsPage() {
               <PublicPollListItem key={poll._id} poll={poll} />
             )
           )}
+          {data.polls.length === 0 && (
+            <Text fontSize='sm' fontStyle='italic'>
+              {l('page.groups.noPolls')}
+            </Text>
+          )}
           {data.isAdmin && (
             <NavButton to={joinPath(UIPaths.NEW_POLL + `?groupId=${id}`)}>{l('title.createPoll')}</NavButton>
           )}

--- a/packages/frontend/src/pages/group/GroupDetails.page.tsx
+++ b/packages/frontend/src/pages/group/GroupDetails.page.tsx
@@ -1,0 +1,72 @@
+import {
+  Button,
+  ButtonGroup,
+  CardBody,
+  CardFooter,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverFooter,
+  PopoverTrigger,
+  Text,
+} from '@chakra-ui/react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { NavButton } from '../../components/button/NavButton';
+import { UIPaths } from '../../config/paths.config';
+import { Page } from '../../layout/Page';
+import { useDeleteGroup } from '../../network/groups/useDeleteGroup.network';
+import { useGroup } from '../../network/groups/useGroup.network';
+import { l } from '../../utils/language';
+import { joinPath } from '../../utils/path';
+import { ErrorPage } from '../utility/Error.page';
+import { LoadingPage } from '../utility/Loading.page';
+
+export function GroupDetailsPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { isLoading, data, isError } = useGroup(id || '');
+  const {
+    isLoading: isDeleteLoading,
+    isError: isDeleteError,
+    mutate,
+  } = useDeleteGroup(id, () => navigate(UIPaths.GROUP));
+  if (isLoading) return <LoadingPage />;
+  if (!data || !id || isError || isDeleteError) return <ErrorPage />;
+  const onDelete = () => {
+    mutate(undefined);
+  };
+  return (
+    <Page title={data.name || l('title.unknown')} isLoading={isLoading}>
+      <CardBody></CardBody>
+      <CardFooter>
+        <ButtonGroup>
+          <NavButton to={joinPath(UIPaths.GROUP, id, 'edit')}>{l('button.edit')}</NavButton>
+          <Popover>
+            <PopoverTrigger>
+              <Button colorScheme='red' variant='ghost'>
+                {l('button.delete')}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent>
+              <PopoverCloseButton />
+              <PopoverArrow />
+              <PopoverBody>
+                <Text>{l('header.confirmDelete')}</Text>
+              </PopoverBody>
+              <PopoverFooter>
+                <ButtonGroup>
+                  <Button isLoading={isDeleteLoading} onClick={onDelete} colorScheme='red' variant='ghost'>
+                    {l('button.delete')}
+                  </Button>
+                </ButtonGroup>
+              </PopoverFooter>
+            </PopoverContent>
+          </Popover>
+        </ButtonGroup>
+      </CardFooter>
+    </Page>
+  );
+}

--- a/packages/frontend/src/pages/group/GroupDetails.page.tsx
+++ b/packages/frontend/src/pages/group/GroupDetails.page.tsx
@@ -18,6 +18,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { NavButton } from '../../components/button/NavButton';
 import { AddMember } from '../../components/group/AddMember';
 import { MemberListItem } from '../../components/group/MemberListItem';
+import { PollListItem } from '../../components/poll/PollListItem';
+import { PublicPollListItem } from '../../components/poll/PublicPollListItem';
 import { UIPaths } from '../../config/paths.config';
 import { Page } from '../../layout/Page';
 import { useDeleteGroup } from '../../network/groups/useDeleteGroup.network';
@@ -44,7 +46,23 @@ export function GroupDetailsPage() {
   return (
     <Page title={data.name || l('title.unknown')} isLoading={isLoading}>
       <CardBody>
-        <VStack spacing={4}>
+        <Text fontSize='xl'>{l('title.polls')}</Text>
+        <VStack spacing={4} mt={2} alignItems='start'>
+          {data.polls.map((poll) =>
+            data.isAdmin ? (
+              <PollListItem key={poll._id} poll={poll} />
+            ) : (
+              <PublicPollListItem key={poll._id} poll={poll} />
+            )
+          )}
+          {data.isAdmin && (
+            <NavButton to={joinPath(UIPaths.NEW_POLL + `?groupId=${id}`)}>{l('title.createPoll')}</NavButton>
+          )}
+        </VStack>
+      </CardBody>
+      <CardBody>
+        <Text fontSize='xl'>{l('title.members')}</Text>
+        <VStack spacing={4} mt={2}>
           {data.members.map((member) => (
             <MemberListItem
               onDelete={refetch}

--- a/packages/frontend/src/pages/group/Groups.page.tsx
+++ b/packages/frontend/src/pages/group/Groups.page.tsx
@@ -15,7 +15,7 @@ export function GroupsPage() {
   if (isLoading) return <LoadingPage />;
   if (!data || isError) return <ErrorPage />;
   return (
-    <Page title='Groups'>
+    <Page title={l('title.groups')}>
       <CardBody>
         <VStack w='100%'>
           {data && data.length > 0 ? (

--- a/packages/frontend/src/pages/group/Groups.page.tsx
+++ b/packages/frontend/src/pages/group/Groups.page.tsx
@@ -1,0 +1,35 @@
+import { ButtonGroup, CardBody, CardFooter, VStack } from '@chakra-ui/react';
+
+import { NavButton } from '../../components/button/NavButton';
+import { EmptyListPlaceholder } from '../../components/feedback/EmptyListPlaceholder';
+import { GroupListItem } from '../../components/group/GroupListItem';
+import { UIPaths } from '../../config/paths.config';
+import { Page } from '../../layout/Page';
+import { useGroups } from '../../network/groups/useGroups.network';
+import { l } from '../../utils/language';
+import { ErrorPage } from '../utility/Error.page';
+import { LoadingPage } from '../utility/Loading.page';
+
+export function GroupsPage() {
+  const { isLoading, data, isError } = useGroups();
+  if (isLoading) return <LoadingPage />;
+  if (!data || isError) return <ErrorPage />;
+  return (
+    <Page title='Groups'>
+      <CardBody>
+        <VStack w='100%'>
+          {data && data.length > 0 ? (
+            data.map((group) => <GroupListItem group={group} key={group._id} />)
+          ) : (
+            <EmptyListPlaceholder />
+          )}
+        </VStack>
+      </CardBody>
+      <CardFooter>
+        <ButtonGroup>
+          <NavButton to={UIPaths.NEW_GROUP}>{l('button.create')}</NavButton>
+        </ButtonGroup>
+      </CardFooter>
+    </Page>
+  );
+}

--- a/packages/frontend/src/pages/poll/CreatePoll.page.tsx
+++ b/packages/frontend/src/pages/poll/CreatePoll.page.tsx
@@ -13,12 +13,13 @@ import {
 } from '@chakra-ui/react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { NavButton } from '../../components/button/NavButton';
 import { AnswerOptionsField } from '../../components/poll/AnswerOptionsField';
 import { UIPaths } from '../../config/paths.config';
 import { Page } from '../../layout/Page';
+import { useGroups } from '../../network/groups/useGroups.network';
 import { useCreatePoll } from '../../network/poll/useCreatePoll.network';
 import { CreatePollDto } from '../../types/dto.types';
 import { l } from '../../utils/language';
@@ -28,14 +29,26 @@ import { pollValidation } from '../../utils/validation';
 
 export function CreatePollPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const adminGroups = useGroups(true);
   const { isLoading, mutate } = useCreatePoll((responseData) => {
     navigate(joinPath(UIPaths.POLL, responseData._id));
   });
+  const group = searchParams.get('groupId');
   const form = useForm<CreatePollDto>({
     resolver: yupResolver(pollValidation),
-    defaultValues: { name: '', enabled: false, confidential: false, question: '', type: 0, answerOptions: [] },
+    defaultValues: {
+      name: '',
+      enabled: Boolean(group),
+      confidential: Boolean(group),
+      question: '',
+      type: 0,
+      answerOptions: [],
+      group: group ?? '',
+    },
   });
   const {
+    watch,
     register,
     handleSubmit,
     formState: { errors },
@@ -48,6 +61,7 @@ export function CreatePollPage() {
       question: values.question,
       type: +values.type,
       answerOptions: values.answerOptions,
+      group: values.group || undefined,
     });
   };
   return (
@@ -89,6 +103,22 @@ export function CreatePollPage() {
                 <FormLabel>{l('form.poll.label.confidential')}</FormLabel>
                 <Switch {...register('confidential')} />
               </FormControl>
+              {watch('confidential') && adminGroups.data && adminGroups.data.length > 0 && (
+                <FormControl isInvalid={!!errors.group}>
+                  <FormLabel>{l('form.poll.label.group')}</FormLabel>
+                  <Select {...register('group')}>
+                    {adminGroups.data?.map((group) => (
+                      <option value={group._id} key={group._id}>
+                        {group.name}
+                      </option>
+                    ))}
+                    <option value='' key=''>
+                      {l('form.poll.placeholder.group')}
+                    </option>
+                  </Select>
+                  {!!errors.group && <FormErrorMessage>{errors.group.message}</FormErrorMessage>}
+                </FormControl>
+              )}
             </VStack>
           </CardBody>
           <CardFooter>

--- a/packages/frontend/src/pages/poll/FillPoll.page.tsx
+++ b/packages/frontend/src/pages/poll/FillPoll.page.tsx
@@ -27,11 +27,12 @@ import { confidentialSubmissionValidation, submissionValidation } from '../../ut
 import { ErrorPage } from '../utility/Error.page';
 import { LoadingPage } from '../utility/Loading.page';
 import { FillPollDisabledPage } from './FillPollDisabled.page';
+import { FillPollSuccessPage } from './FillPollSuccess.page';
 
 export function FillPollPage() {
   const { id } = useParams();
   const { data, isLoading, isError } = usePublicPoll(id);
-  const { isAuthenticated, user } = useAuthContext();
+  const { user } = useAuthContext();
   const navigate = useNavigate();
   const { isLoading: isSubmitLoading, mutate } = useCreateSubmission(id, () => navigate(UIPaths.FILL_SUCCESS));
   const form = useForm<CreateSubmissionDto>({
@@ -47,9 +48,6 @@ export function FillPollPage() {
 
   useEffect(() => {
     if (data) {
-      if (data.confidential && !isAuthenticated) {
-        navigate(UIPaths.LOGIN);
-      }
       reset({ answers: getDefaultAnswerArray(data.answerOptions) });
     }
   }, [data]);
@@ -66,6 +64,7 @@ export function FillPollPage() {
   if (!data.enabled) {
     return <FillPollDisabledPage title={data.question} />;
   }
+  if (data.submission) return <FillPollSuccessPage />;
   return (
     <Page title={data.question}>
       <FormProvider {...form}>

--- a/packages/frontend/src/pages/poll/FillPoll.page.tsx
+++ b/packages/frontend/src/pages/poll/FillPoll.page.tsx
@@ -36,7 +36,7 @@ export function FillPollPage() {
   const navigate = useNavigate();
   const { isLoading: isSubmitLoading, mutate } = useCreateSubmission(id, () => navigate(UIPaths.FILL_SUCCESS));
   const form = useForm<CreateSubmissionDto>({
-    resolver: yupResolver(data?.confidential ? confidentialSubmissionValidation : submissionValidation),
+    resolver: yupResolver(data?.confidential || data?.group ? confidentialSubmissionValidation : submissionValidation),
     defaultValues: { name: '', answers: getDefaultAnswerArray(data?.answerOptions ?? []) },
   });
   const {
@@ -55,7 +55,7 @@ export function FillPollPage() {
   if (isLoading) return <LoadingPage />;
   if (!data || isError) return <ErrorPage message={l('error.notFound')} />;
   const onSubmit = (values: CreateSubmissionDto) => {
-    if (data.confidential) {
+    if (data.confidential || data.group) {
       mutate({ ...values, name: user?.authId ?? '' });
     } else {
       mutate(values);
@@ -72,7 +72,7 @@ export function FillPollPage() {
           <Card>
             <CardBody>
               <VStack spacing={5}>
-                {!data.confidential && (
+                {!data.confidential && !data.group && (
                   <FormControl isInvalid={!!errors.name}>
                     <FormLabel>{l('form.poll.label.name')}</FormLabel>
                     <Input {...register('name')} />

--- a/packages/frontend/src/pages/poll/FillPollSuccess.page.tsx
+++ b/packages/frontend/src/pages/poll/FillPollSuccess.page.tsx
@@ -26,7 +26,7 @@ export function FillPollSuccessPage() {
         <CardFooter>
           <Center>
             {isAuthenticated ? (
-              <Button onClick={() => navigate(-1)}>{l('page.back')}</Button>
+              <Button onClick={() => navigate(-2)}>{l('page.back')}</Button>
             ) : (
               <NavButton to={UIPaths.ROOT}>{l('page.login.back')}</NavButton>
             )}

--- a/packages/frontend/src/pages/poll/FillPollSuccess.page.tsx
+++ b/packages/frontend/src/pages/poll/FillPollSuccess.page.tsx
@@ -1,13 +1,17 @@
-import { Box, Card, CardBody, CardFooter, Center, Text, useColorModeValue, VStack } from '@chakra-ui/react';
+import { Box, Button, Card, CardBody, CardFooter, Center, Text, useColorModeValue, VStack } from '@chakra-ui/react';
 import { TbCircleCheckFilled } from 'react-icons/tb';
+import { useNavigate } from 'react-router-dom';
 
 import { NavButton } from '../../components/button/NavButton';
 import { UIPaths } from '../../config/paths.config';
+import { useAuthContext } from '../../context/auth.context';
 import { Page } from '../../layout/Page';
 import { l } from '../../utils/language';
 
 export function FillPollSuccessPage() {
+  const { isAuthenticated } = useAuthContext();
   const green = useColorModeValue('green.500', 'green.300');
+  const navigate = useNavigate();
   return (
     <Page title={l('page.pollSuccess.title')}>
       <Card>
@@ -21,7 +25,11 @@ export function FillPollSuccessPage() {
         </CardBody>
         <CardFooter>
           <Center>
-            <NavButton to={UIPaths.ROOT}>{l('page.login.back')}</NavButton>
+            {isAuthenticated ? (
+              <Button onClick={() => navigate(-1)}>{l('page.back')}</Button>
+            ) : (
+              <NavButton to={UIPaths.ROOT}>{l('page.login.back')}</NavButton>
+            )}
           </Center>
         </CardFooter>
       </Card>

--- a/packages/frontend/src/pages/poll/NotVotedMembers.tsx
+++ b/packages/frontend/src/pages/poll/NotVotedMembers.tsx
@@ -1,0 +1,18 @@
+import { VStack } from '@chakra-ui/react';
+import { TbLoader } from 'react-icons/tb';
+
+import { IconLabel } from '../../components/common/IconLabel';
+import { l } from '../../utils/language';
+
+export function NotVotedMembers({ notVoted }: { notVoted: string[] }) {
+  return (
+    <VStack alignItems='flex-start' gap={0}>
+      <IconLabel text={l('page.pollDetails.notVoted')} icon={<TbLoader />} />
+      <VStack alignItems='flex-start' gap={1}>
+        {notVoted.map((u) => (
+          <p key={u}>{u}</p>
+        ))}
+      </VStack>
+    </VStack>
+  );
+}

--- a/packages/frontend/src/pages/poll/PollDetails.page.tsx
+++ b/packages/frontend/src/pages/poll/PollDetails.page.tsx
@@ -122,7 +122,7 @@ export function PollDetailsPage() {
             </HStack>
             {pollPatch.isError && <Text color='red'>{l('error.general')}</Text>}
           </Box>
-          {data.group && data.confidential && data.notVoted.length > 0 && <NotVotedMembers notVoted={data.notVoted} />}
+          {data.group && data.notVoted.length > 0 && <NotVotedMembers notVoted={data.notVoted} />}
           {data.confidential ? (
             data.enabled ? (
               <EmptyListPlaceholder text={l('page.pollDetails.activeConfidential')} hideArrow />
@@ -136,6 +136,7 @@ export function PollDetailsPage() {
           ) : (
             <EmptyListPlaceholder text={l('page.pollDetails.empty')} hideArrow />
           )}
+          {data.group && !data.confidential && <ConfidentialVoteResult results={data.results ?? []} />}
         </VStack>
       </CardBody>
       <CardFooter>

--- a/packages/frontend/src/pages/poll/PollDetails.page.tsx
+++ b/packages/frontend/src/pages/poll/PollDetails.page.tsx
@@ -140,6 +140,7 @@ export function PollDetailsPage() {
       </CardBody>
       <CardFooter>
         <ButtonGroup>
+          {data.group && <NavButton to={joinPath(UIPaths.GROUP, data.group)}>{l('button.backToGroup')}</NavButton>}
           <NavButton to={joinPath(UIPaths.POLL, id, 'edit')}>{l('button.edit')}</NavButton>
           <Popover>
             <PopoverTrigger>

--- a/packages/frontend/src/pages/poll/PollDetails.page.tsx
+++ b/packages/frontend/src/pages/poll/PollDetails.page.tsx
@@ -40,6 +40,7 @@ import { l } from '../../utils/language';
 import { joinPath } from '../../utils/path';
 import { ErrorPage } from '../utility/Error.page';
 import { LoadingPage } from '../utility/Loading.page';
+import { NotVotedMembers } from './NotVotedMembers';
 
 export function PollDetailsPage() {
   const green = useColorModeValue('green.500', 'green.300');
@@ -121,6 +122,7 @@ export function PollDetailsPage() {
             </HStack>
             {pollPatch.isError && <Text color='red'>{l('error.general')}</Text>}
           </Box>
+          {data.group && data.confidential && data.notVoted.length > 0 && <NotVotedMembers notVoted={data.notVoted} />}
           {data.confidential ? (
             data.enabled ? (
               <EmptyListPlaceholder text={l('page.pollDetails.activeConfidential')} hideArrow />

--- a/packages/frontend/src/types/dto.types.ts
+++ b/packages/frontend/src/types/dto.types.ts
@@ -2,7 +2,7 @@ import { Group, Link, Poll, Submission } from './types';
 
 export type CreateLinkDto = Omit<Link, 'timestamps' | 'shortId'> & { shortId?: Link['shortId'] };
 export type PatchLinkDto = Partial<Omit<Link, 'timestamps' | 'shortId'>>;
-export type CreatePollDto = Poll;
+export type CreatePollDto = Omit<Poll, 'submission'>;
 export type PatchPollDto = Partial<Poll>;
 export type CreateSubmissionDto = Omit<Submission, 'poll'>;
 export type SetRoleDto = { isAdmin: boolean };

--- a/packages/frontend/src/types/dto.types.ts
+++ b/packages/frontend/src/types/dto.types.ts
@@ -1,4 +1,4 @@
-import { Link, Poll, Submission } from './types';
+import { Group, Link, Poll, Submission } from './types';
 
 export type CreateLinkDto = Omit<Link, 'timestamps' | 'shortId'> & { shortId?: Link['shortId'] };
 export type PatchLinkDto = Partial<Omit<Link, 'timestamps' | 'shortId'>>;
@@ -6,3 +6,5 @@ export type CreatePollDto = Poll;
 export type PatchPollDto = Partial<Poll>;
 export type CreateSubmissionDto = Omit<Submission, 'poll'>;
 export type SetRoleDto = { isAdmin: boolean };
+export type CreateGroupDto = Omit<Group, 'memberIds' | 'admin'>;
+export type PatchGroupDto = Partial<Omit<Group, 'memberIds' | 'admin'>>;

--- a/packages/frontend/src/types/dto.types.ts
+++ b/packages/frontend/src/types/dto.types.ts
@@ -8,3 +8,5 @@ export type CreateSubmissionDto = Omit<Submission, 'poll'>;
 export type SetRoleDto = { isAdmin: boolean };
 export type CreateGroupDto = Omit<Group, 'memberIds' | 'admin'>;
 export type PatchGroupDto = Partial<Omit<Group, 'memberIds' | 'admin'>>;
+export type AddMemberToGroupDto = { memberMail: string };
+export type RemoveMemberFromGroupDto = { memberId: string };

--- a/packages/frontend/src/types/types.ts
+++ b/packages/frontend/src/types/types.ts
@@ -69,6 +69,13 @@ export type Group = {
   memberIds: string[];
 };
 
+export type GroupDetails = {
+  name: string;
+  isAdmin: boolean;
+  members: UserDocument[];
+  polls: PollDocument[];
+};
+
 export type RouterItem = MenuPage | RoutePage;
 
 export type MenuPage = {

--- a/packages/frontend/src/types/types.ts
+++ b/packages/frontend/src/types/types.ts
@@ -11,6 +11,7 @@ export type LinkDocument = Document<Link>;
 export type PollDocument = Document<Poll>;
 export type SubmissionDocument = Document<Submission>;
 export type PollDocumentWithSubmissions = Document<PollWithSubmissions>;
+export type GroupDocument = Document<Group>;
 
 export enum PollType {
   SINGLE,
@@ -60,6 +61,12 @@ export type Link = {
   shortId: string;
   url: string;
   timestamps: number[];
+};
+
+export type Group = {
+  name: string;
+  admin: string;
+  memberIds: string[];
 };
 
 export type RouterItem = MenuPage | RoutePage;

--- a/packages/frontend/src/types/types.ts
+++ b/packages/frontend/src/types/types.ts
@@ -34,7 +34,11 @@ export type ConfidentialPollResult = {
   key: string;
 } & { [K in SubmissionAnswerValue]: number };
 
-export type PollWithSubmissions = Poll & { submissions?: SubmissionDocument[]; results?: ConfidentialPollResult[] };
+export type PollWithSubmissions = Poll & {
+  submissions?: SubmissionDocument[];
+  results?: ConfidentialPollResult[];
+  notVoted: string[];
+};
 
 export enum SubmissionAnswerValue {
   NO,

--- a/packages/frontend/src/types/types.ts
+++ b/packages/frontend/src/types/types.ts
@@ -26,6 +26,7 @@ export type Poll = {
   question: string;
   type: PollType;
   answerOptions: string[];
+  submission?: SubmissionDocument;
 };
 
 export type ConfidentialPollResult = {

--- a/packages/frontend/src/types/types.ts
+++ b/packages/frontend/src/types/types.ts
@@ -26,6 +26,7 @@ export type Poll = {
   question: string;
   type: PollType;
   answerOptions: string[];
+  group?: string;
   submission?: SubmissionDocument;
 };
 
@@ -70,11 +71,15 @@ export type Group = {
   memberIds: string[];
 };
 
+export type PollWithSubmissionsDocument = PollDocument & {
+  submissions: SubmissionDocument[];
+};
+
 export type GroupDetails = {
   name: string;
   isAdmin: boolean;
   members: UserDocument[];
-  polls: PollDocument[];
+  polls: PollWithSubmissionsDocument[];
 };
 
 export type RouterItem = MenuPage | RoutePage;

--- a/packages/frontend/src/utils/language.ts
+++ b/packages/frontend/src/utils/language.ts
@@ -26,6 +26,7 @@ const languageData = {
   'error.notFound': 'Nem található',
   'error.create': 'Létrehozás sikertelen',
   'error.save': 'Mentés sikertelen',
+  'error.addMember': 'Tag hozzáadása sikertelen',
   'success.save': 'Sikeres mentés',
   'button.add': 'Hozzáadás',
   'button.duplicate': 'Hozzáadás',
@@ -108,4 +109,5 @@ const languageData = {
   'page.pollSuccess.title': 'Szavazat beküldve',
   'page.pollSuccess.description': 'A szavazatod megkaptuk!',
   'page.pollSuccess.disabled': 'A szavazás nincs engedélyezve!',
+  'page.groups.addMember': 'Tag hozzáadása',
 };

--- a/packages/frontend/src/utils/language.ts
+++ b/packages/frontend/src/utils/language.ts
@@ -16,6 +16,9 @@ const languageData = {
   'title.login': 'Bejelentkezés',
   'title.dashboard': 'Dashboard',
   'title.users': 'Felhasználók',
+  'title.groups': 'Csoportok',
+  'title.editGroup': 'Csoport szerkesztése',
+  'title.createGroup': 'Csoport létrehozása',
   'error.wrongCredentials': 'Hibás bejelentkezési adatok',
   'error.unauthorized': 'Nem vagy bejelentkezve',
   'error.forbidden': 'Nincs jogosultságod',
@@ -53,7 +56,7 @@ const languageData = {
     'Az kitöltésekben található válaszok a szöveg alapján vannak elmentve és hivatkozva. Amennyiben módosítod egy lehetőség szövegét, úgy egyes válaszok nem kerülnek megjelenítésre (de továbbra is megmaradnak)!',
   'form.poll.tip.answerOptions':
     'Beérkezett kitöltések után a kérdések szerkesztését nem javasoljuk, a kérdés felvételét, törlését és sorrendmódosítást ajánljuk!',
-
+  'form.group.label.name': 'Név',
   'navbar.section.user': 'Felhasználó',
   'navbar.section.things': 'Dolgaim',
   'navbar.unknown': 'Ismeretlen',

--- a/packages/frontend/src/utils/language.ts
+++ b/packages/frontend/src/utils/language.ts
@@ -40,6 +40,7 @@ const languageData = {
   'button.cancel': 'Mégse',
   'button.reset': 'Módosítások elvetése',
   'button.continue': 'Tovább',
+  'button.backToGroup': 'Vissza a csoporthoz',
   'header.confirmDelete': 'Biztosan törlöd?',
   'text.emptyList': 'Itt nincs semmi. Egyelőre. Hozz létre valami újat!',
   'form.validation.required': 'Nem lenne szép üresen hagyni!',
@@ -117,4 +118,5 @@ const languageData = {
   'page.pollSuccess.description': 'A szavazatod megkaptuk!',
   'page.pollSuccess.disabled': 'A szavazás nincs engedélyezve!',
   'page.groups.addMember': 'Tag hozzáadása e-mail cím alapján',
+  'page.groups.noPolls': 'Nincs egyetlen szavazás se',
 };

--- a/packages/frontend/src/utils/language.ts
+++ b/packages/frontend/src/utils/language.ts
@@ -30,6 +30,8 @@ const languageData = {
   'error.addMember': 'Tag hozzáadása sikertelen',
   'success.save': 'Sikeres mentés',
   'button.add': 'Hozzáadás',
+  'button.addOption': 'Új válaszlehetőség',
+  'button.triple': 'Igen/Nem/Tartózkodom hozzáadása',
   'button.duplicate': 'Hozzáadás',
   'button.delete': 'Törlés',
   'button.edit': 'Szerkesztés',
@@ -95,6 +97,7 @@ const languageData = {
   'page.pollDetails.reenableConfidential':
     'Bizalmast szavazást nem lehet újra engedélyezni, ha már érkeztek be szavazatok!',
   'page.pollDetails.mostVote': 'Legtöbb "Igen" szavazat erre volt:',
+  'page.pollDetails.notVoted': 'Tagok, akik még nem szavaztak:',
   'page.dashboard.tileHelpText': 'Átirányítás',
   'page.landing.button': 'Vágjunk bele!',
   'page.landing.title': 'Link rövidítés egyszerűen',

--- a/packages/frontend/src/utils/language.ts
+++ b/packages/frontend/src/utils/language.ts
@@ -19,6 +19,7 @@ const languageData = {
   'title.groups': 'Csoportok',
   'title.editGroup': 'Csoport szerkesztése',
   'title.createGroup': 'Csoport létrehozása',
+  'title.members': 'Tagok',
   'error.wrongCredentials': 'Hibás bejelentkezési adatok',
   'error.unauthorized': 'Nem vagy bejelentkezve',
   'error.forbidden': 'Nincs jogosultságod',
@@ -52,7 +53,9 @@ const languageData = {
   'form.poll.label.question': 'Kérdés / felszólítás',
   'form.poll.label.answerOptions': 'Válaszlehetőségek',
   'form.poll.label.enabled': 'Kitöltés engedélyezve alapból',
-  'form.poll.label.confidential': 'Bizalmas szavazás. Csak bejelentkezett felhasználók tudnak szavazni',
+  'form.poll.label.confidential': 'Bizalmas szavazás, azaz csak bejelentkezett felhasználók tudnak szavazni.',
+  'form.poll.label.group': 'Csoportra korlátozás',
+  'form.poll.placeholder.group': 'Nincs csoport',
   'form.poll.warning.answerOptions':
     'Az kitöltésekben található válaszok a szöveg alapján vannak elmentve és hivatkozva. Amennyiben módosítod egy lehetőség szövegét, úgy egyes válaszok nem kerülnek megjelenítésre (de továbbra is megmaradnak)!',
   'form.poll.tip.answerOptions':
@@ -71,6 +74,7 @@ const languageData = {
     'Jelentkezz be AuthSch fiókoddal! A profilod automatikusan létrejön az első bejelentkezés alkalmával.',
   'page.login.button': 'Bejelentkezés',
   'page.login.back': 'Vissza a főoldalra',
+  'page.back': 'Vissza',
   'page.linkDetails.copySuccess': 'Másolva!',
   'page.linkDetails.copyFail': 'Sikertelen másolás!',
   'page.linkDetails.fullUrl': 'Teljes URL',
@@ -109,5 +113,5 @@ const languageData = {
   'page.pollSuccess.title': 'Szavazat beküldve',
   'page.pollSuccess.description': 'A szavazatod megkaptuk!',
   'page.pollSuccess.disabled': 'A szavazás nincs engedélyezve!',
-  'page.groups.addMember': 'Tag hozzáadása',
+  'page.groups.addMember': 'Tag hozzáadása e-mail cím alapján',
 };

--- a/packages/frontend/src/utils/validation.ts
+++ b/packages/frontend/src/utils/validation.ts
@@ -1,6 +1,6 @@
 import { array, boolean, number, object, SchemaOf, string } from 'yup';
 
-import { CreateLinkDto, CreatePollDto, CreateSubmissionDto } from '../types/dto.types';
+import { CreateGroupDto, CreateLinkDto, CreatePollDto, CreateSubmissionDto } from '../types/dto.types';
 import { l } from './language';
 
 const urlRegex = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i;
@@ -28,4 +28,8 @@ export const submissionValidation: SchemaOf<CreateSubmissionDto> = object({
 export const confidentialSubmissionValidation: SchemaOf<CreateSubmissionDto> = object({
   name: string().default(''),
   answers: array(),
+});
+
+export const groupValidation: SchemaOf<CreateGroupDto> = object({
+  name: string().required(l('form.validation.required')),
 });

--- a/packages/frontend/src/utils/validation.ts
+++ b/packages/frontend/src/utils/validation.ts
@@ -1,6 +1,12 @@
 import { array, boolean, number, object, SchemaOf, string } from 'yup';
 
-import { CreateGroupDto, CreateLinkDto, CreatePollDto, CreateSubmissionDto } from '../types/dto.types';
+import {
+  AddMemberToGroupDto,
+  CreateGroupDto,
+  CreateLinkDto,
+  CreatePollDto,
+  CreateSubmissionDto,
+} from '../types/dto.types';
 import { l } from './language';
 
 const urlRegex = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/i;
@@ -32,4 +38,8 @@ export const confidentialSubmissionValidation: SchemaOf<CreateSubmissionDto> = o
 
 export const groupValidation: SchemaOf<CreateGroupDto> = object({
   name: string().required(l('form.validation.required')),
+});
+
+export const addMemberValidation: SchemaOf<AddMemberToGroupDto> = object({
+  memberMail: string().email(l('form.validation.email')).required(l('form.validation.required')),
 });

--- a/packages/frontend/src/utils/validation.ts
+++ b/packages/frontend/src/utils/validation.ts
@@ -24,6 +24,7 @@ export const pollValidation: SchemaOf<CreatePollDto> = object({
   question: string().required(l('form.validation.required')),
   type: number().required(l('form.validation.required')),
   answerOptions: array().min(1, l('form.validation.min')),
+  group: string().optional(),
 });
 
 export const submissionValidation: SchemaOf<CreateSubmissionDto> = object({


### PR DESCRIPTION
- Standard CRUD endpoints for the Group resource. only needs a name to be created
- POST and DELETE `groups/:id/members` endpoints for adding and removing members. Needs an object with a `members` key as request body, the value is an array of the authIds of users to add to / remove from the group
- the findAll endpoint doesn't return the member list, just an isAdmin flag on the group object
- the findOne endpoint also returns the polls of the group
- all GET endpoints return all the groups you're a member or admin of
- optional group field in the Poll model. If it's not empty, only group members can vote on that poll
- the poll findOne endpoint returns a voteInfo object if the poll is for a group and it's confidential. This object has a voted and a notVoted field, both are string[]s. They contain the displayNames of the users who have voted or hasn't voted. In case the user has never logged in to the app but is a member of the group (could be the case at Interkoll), their authId will be in the array, since we don't know their name


and much, much more